### PR TITLE
Add missing deps to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ovos-utils~=0.0, >=0.0.28
 ovos_workshop~=0.0, >=0.0.12a27
 ovos-bus-client
+ovos-config


### PR DESCRIPTION
ovos-core and ovos-config are used in __init__.py