### PR TITLE
fix: allow workshop 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ovos-utils>=0.0.38
-ovos-workshop>=0.0.15,<2.0.0
+ovos-workshop>=0.0.15,<3.0.0
 ovos-bus-client>=0.0.8


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the `ovos-workshop` package to allow a broader range of versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->