### PR TITLE
Complete French naptime locale

### DIFF
--- a/locale/fr-fr/SleepCommand.voc
+++ b/locale/fr-fr/SleepCommand.voc
@@ -1,2 +1,4 @@
 sieste
 va te coucher
+mode veille
+va dormir

--- a/locale/fr-fr/going.to.sleep.dialog
+++ b/locale/fr-fr/going.to.sleep.dialog
@@ -1,3 +1,3 @@
-D'accord, je vais me coucher. Vous pouvez me réveiller en disant '{wake_word}, réveille-toi'.
-Je vais dormir maintenant. Dites '{wake_word}, réveille-toi' pour me réveiller.
-Je vais me coucher. Dites '{wake_word}, réveille-toi' pour attirer à nouveau mon attention.
+D'accord, je me mets en veille. Dites '{wake_word}, réveille-toi' pour me réveiller.
+Je vais dormir un moment. Dites '{wake_word}, réveille-toi' quand vous aurez besoin de moi.
+Très bien, je vais me taire. Dites '{wake_word}, réveille-toi' pour attirer de nouveau mon attention.

--- a/locale/fr-fr/going.to.sleep.short.dialog
+++ b/locale/fr-fr/going.to.sleep.short.dialog
@@ -1,2 +1,2 @@
-Je vais me coucher.
-Okay.
+Je me mets en veille.
+Très bien.

--- a/locale/fr-fr/i.am.awake.dialog
+++ b/locale/fr-fr/i.am.awake.dialog
@@ -1,1 +1,2 @@
-Je suis réveillé
+Je suis réveillé.
+Je suis de retour.

--- a/locale/fr-fr/naptime.intent
+++ b/locale/fr-fr/naptime.intent
@@ -1,0 +1,7 @@
+va te coucher
+mode veille
+fais une sieste
+mets-toi en veille
+va dormir
+il est temps de dormir
+c'est l'heure de la sieste

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,0 +1,17 @@
+{
+  "skill_id": "ovos-skill-naptime.openvoiceos",
+  "source": "https://github.com/OpenVoiceOS/ovos-skill-naptime",
+  "name": "Sieste",
+  "description": "Met l'assistant en veille quand vous ne voulez pas être dérangé.",
+  "examples": [
+    "Va te coucher",
+    "C'est l'heure de la sieste",
+    "Réveille-toi"
+  ],
+  "tags": [
+    "sieste",
+    "veille",
+    "sommeil",
+    "ne-pas-déranger"
+  ]
+}

--- a/locale/fr-fr/wakeup.voc
+++ b/locale/fr-fr/wakeup.voc
@@ -1,0 +1,2 @@
+réveille-toi
+réveille toi


### PR DESCRIPTION
## Summary
- add the missing French naptime intent, wakeup vocabulary, and localized skill metadata
- refine the spoken sleep and wake dialogs so they sound natural for a voice assistant

## Validation
- verified fr-fr file coverage against locale/en-us
- validated locale/fr-fr/skill.json parses as JSON

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive French language support for sleep and naptime commands, enabling French-speaking users to control the assistant with new voice phrases for entering sleep mode and waking up.

* **Documentation**
  * Added French skill metadata and locale information for the naptime feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->