### PR TITLE
chore(ovos-skill-naptime): allow ovos-workshop<9.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ovos-utils>=0.0.38
-ovos-workshop>=0.0.15,<8.0.0
+ovos-workshop>=0.0.15,<9.0.0
 ovos-bus-client>=1.2.0,<2.0.0


### PR DESCRIPTION
Update ovos-workshop dependency upper bound to <9.0.0