### PR TITLE
feat: tighten en-US naptime intent definitions to spec

### DIFF
--- a/locale/en-US/naptime.blacklist
+++ b/locale/en-US/naptime.blacklist
@@ -1,0 +1,6 @@
+# Suppress naptime for timer, alarm, and media requests that merely share the
+# word "sleep" with a naptime phrasing but belong to another skill, such as
+# "set a sleep timer for ten minutes" or "play some sleep music".
+timer
+alarm
+play

--- a/locale/en-US/naptime.intent
+++ b/locale/en-US/naptime.intent
@@ -1,31 +1,7 @@
-activate sleep mode
-begin downtime
-begin naptime
-begin power nap
-begin sleep interval
-begin sleeping
-enter dreamland
-enter hibernation
-enter rest mode
-enter silent mode
-enter sleep mode
-enter slumber mode
-go to sleep
-initiate naptime
-initiate quiet time
-initiate shut-eye
-initiate siesta
-initiate siesta mode
-initiate sleep mode
-let's go to sleep
-let's have some quiet time
-let's take a nap
-nap time
-start doze-off
-start nap
-start nap period
-start sleep session
-start slumber time
-start snooze mode
-time for a nap
-time to sleep
+(let's |)go to sleep
+(let's |)(take|have) a nap
+(nap time|naptime)
+(it's |)time (for a nap|to sleep)
+(start|begin|take) a (power |)nap
+(enter|activate|start) sleep mode
+(please |)stop listening( to me|)

--- a/locale/en-US/wakeup.voc
+++ b/locale/en-US/wakeup.voc
@@ -1,1 +1,5 @@
 wake up
+wake
+start listening
+stop sleeping
+stop napping


### PR DESCRIPTION
## What

Reviews and improves the **en-US** intent definitions of ovos-skill-naptime against OVOS-INTENT-1/2/3.

### `naptime.intent` (template intent)
- Consolidated ~31 flat, largely synthetic lines into 7 templates using `(a|b)` / `(x|)` expansion covering the real phrasings: *go to sleep, take/have a nap, nap time, time for a nap, time to sleep, (power) nap, sleep mode, stop listening*.
- Dropped terms that belong to (or over-grab for) other skills and are not naptime-specific: `silent mode`, `quiet time` (mute/DND), `hibernation` (device power), `snooze mode` (alarm), `doze-off`, `dreamland`, `downtime`, `slumber/siesta` synthetics.
- Added **`stop listening`** — a strong, unambiguous naptime trigger that was missing.
- No slots are used, so no `.entity` is required and there are no undefined-slot templates.

### `naptime.blacklist` (new, INTENT-3 §5.5)
Suppresses naptime for utterances that merely share the word *sleep* with a naptime phrasing but belong elsewhere:
- `timer` — e.g. *"set a sleep timer for ten minutes"* (timer skill)
- `alarm` — e.g. *"set a sleep alarm"* (alarm skill)
- `play` — e.g. *"play some sleep music"* / *"play sleep sounds"* (OCP/media)

No naptime phrasing contains any of these words, so suppression is safe. This is preferred over loosening templates because the generative grammar cannot express exclusions.

### `wakeup.voc`
Broadened from the single `wake up` to `wake`, `start listening`, `stop sleeping`, `stop napping`. The `WakeUp` keyword intent requires the `sleeping_state` context, so it cannot fire while the assistant is awake — no over-grab risk.

## Testing
- Expansion verified with `ovos_utils.bracket_expansion.expand_options`; all samples expand to clean, non-empty, single-spaced sentences.
- `test_padatious_intents_en.py::TestPadaos` passes.

## Notes (out of scope, pre-existing)
- The en intent unit tests `join(..., "en-us")` but the folder is `en-US`; on a case-sensitive FS the walk finds nothing, so these tests are effectively no-ops (already tracked in TODO.md gaps).
- Only en-US was touched; other languages were intentionally not machine-translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded supported phrases for sleep and wake commands, including more natural ways to say “nap,” “sleep mode,” and “wake up.”
  * Added additional wake-related phrases such as “start listening,” “stop sleeping,” and “stop napping.”

* **Bug Fixes**
  * Reduced accidental matches for timer, alarm, and media requests that sound sleep-related but belong to other actions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->